### PR TITLE
Add ynBNBx February 2026 monthly report

### DIFF
--- a/tokens/ynBNBx/reports/2026/ynbnbx-february-2026.md
+++ b/tokens/ynBNBx/reports/2026/ynbnbx-february-2026.md
@@ -1,0 +1,80 @@
+# YieldNest Monthly Report – ynBNBx (February 2026)
+
+![](https://raw.githubusercontent.com/yieldnest/Publications/refs/heads/main/assets/ynBNBx/report.png)
+
+
+---
+
+**Vault Asset**: ynBNBx
+**Vault Chain**: BNB Chain
+**Vault Type**: MAX
+**Vault Launch Date**: December 2024
+**Period Covered:** February 1 – February 28, 2026
+**Report Date:** March 1, 2026
+
+---
+
+## 1. Executive Summary
+
+[ynBNBx](https://app.yieldnest.finance/token/ynBNBx) is YieldNest’s MAX product deployed on BNB Chain. It auto-compounds BNB yield through Binance rewards and DeFi-native strategies, offering liquid exposure and BNB L1 settlement.
+
+Starting in 2025 August, reward collection has been optimized to automatically convert and compound rewards into BNB, further enhancing yield efficiency.
+
+*Return accrues as the value of ynBNBx increases relative to BNB.*
+
+---
+
+## 2. Vault Overview Report (as of March 1, 2026)
+
+### Monthly Overview Report
+
+* Vault TVL: $546,981.23 (886.2 BNB)
+* Yield Generated: $0 (0 BNB)
+* APY stats from October:
+    * 2026-02-21 - 2026-02-28: -0.93%
+    * 2026-02-01 - 2026-02-28: 0.05%
+
+---
+
+## 3. Strategy Breakdown (as of March 1, 2026)
+
+
+| Asset / Strategy    | Allocation | Protocol      | Description |
+|-------------|------------|-----------|------------------------------------------------|
+| wBNB        | 13.91%      | -         | Pending capital for deployment                 |
+| ynClisBNB   | 75.78%     | YieldNest | Earns Launchpool, Megadrop & HODLer rewards    |
+| slisBNB     | 10.31%     | Listadao  | Lista DAO liquid staking token                 |
+
+
+---
+
+## 4. Yield Generation Breakdown (as of March 1, 2026)
+**Total Airdrop Yield (BNB): 0 BNB**
+
+---
+
+## 5. Security & Risk Monitoring
+
+Audited Completed:
+
+* [Zokyo - Dec 2024](https://github.com/yieldnest/Publications/blob/main/audits/zokyo_audit_yieldnest_dec12th_2024.pdf)
+* [Composable Security - Jan 2025](https://github.com/yieldnest/Publications/blob/main/audits/composable_security_yieldnest_jan_2025.pdf)
+* [Llamarisk - Jan 2025](https://www.llamarisk.com/research/asset-risk-ynbnbx)
+* [NFR Audits Feb 2025](https://github.com/yieldnest/Publications/blob/main/audits/yieldnest_max_vault_withdrawer_audit_report.pdf)
+
+On-Chain Protections:
+* ERC-4626 modular vaults
+* Strategy whitelisting via Guard Engine
+* Proxy upgrade system
+* Bounded execution for slashing/misallocation defense
+
+---
+
+## 6. Notable Events This Month
+
+* ✅ [YieldNest Yield Season: Multi-Protocol Incentives Now Live](https://x.com/YieldNestFi/status/2021841916904845804)
+* ✅ [ynRWAx Surpasses $3M TVL Milestone](https://x.com/YieldNestFi/status/2024122556924780841)
+
+## 7. Outlook & Strategy Notes
+
+* Optimized reward collection to improve yield efficiency and auto-compounding

--- a/tokens/ynBNBx/reports/2026/ynbnbx-february-2026.md
+++ b/tokens/ynBNBx/reports/2026/ynbnbx-february-2026.md
@@ -30,7 +30,7 @@ Starting in 2025 August, reward collection has been optimized to automatically c
 
 * Vault TVL: $546,981.23 (886.2 BNB)
 * Yield Generated: $0 (0 BNB)
-* APY stats from October:
+* APY stats from February:
     * 2026-02-21 - 2026-02-28: -0.93%
     * 2026-02-01 - 2026-02-28: 0.05%
 


### PR DESCRIPTION
Add YieldNest monthly report for the ynBNBx vault covering February 1–28, 2026. The new markdown includes an executive summary, vault overview (TVL, yield, APY), strategy allocation breakdown, yield generation, security & audit references, notable events, and outlook. File added at tokens/ynBNBx/reports/2026/ynbnbx-february-2026.md.