### PR TITLE
docs: add June 2026 monthly reports

### DIFF
--- a/tokens/STAK/reports/2026/stak-june-2026.md
+++ b/tokens/STAK/reports/2026/stak-june-2026.md
@@ -1,0 +1,63 @@
+# YieldNest Monthly Report – STAK (June 2026)
+
+![](https://raw.githubusercontent.com/yieldnest/Publications/refs/heads/main/assets/STAK/report.png)
+
+---
+
+**Vault Asset**: STAK
+**Vault Chain**: Ethereum Chain
+**Vault Type**: MAX
+**Vault Launch Date**: December 2025
+**Period Covered:** June 1 – June 30, 2026
+**Report Date:** July 1, 2026
+
+---
+
+## 1. Executive Summary
+
+[STAK](https://app.yieldnest.finance/token/STAK) is YieldNest's MAX product deployed on Ethereum Chain. It auto-compounds USD yield through DeFi-native strategies, offering liquid exposure and ETH L1 settlement.
+
+_Return accrues as the value of STAK increases relative to USDC._
+
+---
+
+## 2. Vault Overview Report (as of July 1, 2026)
+
+### Monthly Overview Report
+
+- Vault TVL: $259,422.22
+- APY stats from June:
+    - 2026-06-23 - 2026-06-30: 8.32%
+    - 2026-06-01 - 2026-06-30: 7.02%
+
+---
+
+## 3. Strategy Breakdown (as of July 1, 2026)
+
+| Asset / Strategy | Allocation | Protocol | Description |
+| --- | --- | --- | --- |
+| Stake DAO ynRWAx/ynUSDx | 100.00% | StakeDAO | This strategy automatically stakes your yn-RWA/USD in the Curve gauge, and boosts it thanks to the veCRV position owned by the CRV Liquid Locker. |
+
+---
+
+## 4. Security & Risk Monitoring
+
+Audited Completed:
+
+- [Zokyo - Dec 2024](https://github.com/yieldnest/Publications/blob/main/audits/zokyo_audit_yieldnest_dec12th_2024.pdf)
+- [Composable Security - Jan 2025](https://github.com/yieldnest/Publications/blob/main/audits/composable_security_yieldnest_jan_2025.pdf)
+- [Llamarisk - Jan 2025](https://www.llamarisk.com/research/asset-risk-ynbnbx)
+- [NFR Audits Feb 2025](https://github.com/yieldnest/Publications/blob/main/audits/yieldnest_max_vault_withdrawer_audit_report.pdf)
+
+On-Chain Protections:
+
+- ERC-4626 modular vaults
+- Strategy whitelisting via Guard Engine
+- Proxy upgrade system
+- Bounded execution for slashing/misallocation defense
+
+---
+
+## 5. Outlook & Strategy Notes
+
+- Optimized reward collection to improve yield efficiency and auto-compounding

--- a/tokens/ynBNBx/reports/2026/ynbnbx-june-2026.md
+++ b/tokens/ynBNBx/reports/2026/ynbnbx-june-2026.md
@@ -1,0 +1,74 @@
+# YieldNest Monthly Report – ynBNBx (June 2026)
+
+![](https://raw.githubusercontent.com/yieldnest/Publications/refs/heads/main/assets/ynBNBx/report.png)
+
+---
+
+**Vault Asset**: ynBNBx
+**Vault Chain**: BNB Chain
+**Vault Type**: MAX
+**Vault Launch Date**: December 2024
+**Period Covered:** June 1 – June 30, 2026
+**Report Date:** July 1, 2026
+
+---
+
+## 1. Executive Summary
+
+[ynBNBx](https://app.yieldnest.finance/token/ynBNBx) is YieldNest's MAX product deployed on BNB Chain. It auto-compounds BNB yield through Binance rewards and DeFi-native strategies, offering liquid exposure and BNB L1 settlement.
+
+Starting in 2025 August, reward collection has been optimized to automatically convert and compound rewards into BNB, further enhancing yield efficiency.
+
+*Return accrues as the value of ynBNBx increases relative to BNB.*
+
+---
+
+## 2. Vault Overview Report (as of July 1, 2026)
+
+### Monthly Overview Report
+
+- Vault TVL: $83,122.03 (152.31 WBNB)
+- Yield Generated: $0 (0 WBNB)
+- APY stats from June:
+    - 2026-06-23 - 2026-06-30: 1.18%
+    - 2026-06-01 - 2026-06-30: 0.29%
+
+---
+
+## 3. Strategy Breakdown (as of July 1, 2026)
+
+| Asset / Strategy | Allocation | Protocol | Description |
+| --- | --- | --- | --- |
+| wBNB | 53.97% | - | Freshly deposited wBNB ready to be deployed into strategies. |
+| ynBNBx Lending | 45.55% | AAVE | Earns yield by lending WBNB on AAVE, while supporting instant withdrawals for ynBNBx. |
+| ynClisBNB | 0.48% | YieldNest | ynClisBNB is a proprietary Yieldnest strategy that earns rewards from Binance Launchpool, Megadrop, and HODLer Airdrop. |
+
+---
+
+## 4. Yield Generation Breakdown (as of July 1, 2026)
+
+**Total Airdrop Yield (WBNB): 0 WBNB**
+
+---
+
+## 5. Security & Risk Monitoring
+
+Audited Completed:
+
+- [Zokyo - Dec 2024](https://github.com/yieldnest/Publications/blob/main/audits/zokyo_audit_yieldnest_dec12th_2024.pdf)
+- [Composable Security - Jan 2025](https://github.com/yieldnest/Publications/blob/main/audits/composable_security_yieldnest_jan_2025.pdf)
+- [Llamarisk - Jan 2025](https://www.llamarisk.com/research/asset-risk-ynbnbx)
+- [NFR Audits Feb 2025](https://github.com/yieldnest/Publications/blob/main/audits/yieldnest_max_vault_withdrawer_audit_report.pdf)
+
+On-Chain Protections:
+
+- ERC-4626 modular vaults
+- Strategy whitelisting via Guard Engine
+- Proxy upgrade system
+- Bounded execution for slashing/misallocation defense
+
+---
+
+## 6. Outlook & Strategy Notes
+
+- Optimized reward collection to improve yield efficiency and auto-compounding

--- a/tokens/ynETHx/reports/2026/ynethx-june-2026.md
+++ b/tokens/ynETHx/reports/2026/ynethx-june-2026.md
@@ -1,0 +1,66 @@
+# YieldNest Monthly Report – ynETHx (June 2026)
+
+![](https://raw.githubusercontent.com/yieldnest/Publications/refs/heads/main/assets/ynETHx/report.png)
+
+---
+
+**Vault Asset**: ynETHx
+**Vault Chain**: Ethereum Chain
+**Vault Type**: MAX
+**Vault Launch Date**: November 2024
+**Period Covered:** June 1 – June 30, 2026
+**Report Date:** July 1, 2026
+
+---
+
+## 1. Executive Summary
+
+[ynETHx](https://app.yieldnest.finance/token/ynETHx) is YieldNest's MAX product deployed on Ethereum Chain. It auto-compounds ETH yield through DeFi-native strategies, offering liquid exposure and ETH L1 settlement.
+
+_Return accrues as the value of ynETHx increases relative to ETH._
+
+---
+
+## 2. Vault Overview Report (as of July 1, 2026)
+
+### Monthly Overview Report
+
+- Vault TVL: $6,514,603.01 (4,147.21 WETH)
+- APY stats from June:
+    - 2026-06-23 - 2026-06-30: 7.05%
+    - 2026-06-01 - 2026-06-30: 5.80%
+
+---
+
+## 3. Strategy Breakdown (as of July 1, 2026)
+
+| Asset / Strategy | Allocation | Protocol | Description |
+| --- | --- | --- | --- |
+| wstETH / ynRWAx | 89.98% | AAVE | Supply wstETH on Aave, borrow USD to deposit into ynRWAx. |
+| ETH Arbitrage | 9.61% | YieldNest | Delta Neutral Arbitrage Strategy compounding rewards in ETH. |
+| WETH | 0.31% | - | Freshly deposited wETH ready to be deployed into strategies. |
+| wstETH | 0.09% | Lido | Lido wrapped staked ETH |
+
+---
+
+## 4. Security & Risk Monitoring
+
+Audited Completed:
+
+- [Zokyo - Dec 2024](https://github.com/yieldnest/Publications/blob/main/audits/zokyo_audit_yieldnest_dec12th_2024.pdf)
+- [Composable Security - Jan 2025](https://github.com/yieldnest/Publications/blob/main/audits/composable_security_yieldnest_jan_2025.pdf)
+- [Llamarisk - Jan 2025](https://www.llamarisk.com/research/asset-risk-ynbnbx)
+- [NFR Audits Feb 2025](https://github.com/yieldnest/Publications/blob/main/audits/yieldnest_max_vault_withdrawer_audit_report.pdf)
+
+On-Chain Protections:
+
+- ERC-4626 modular vaults
+- Strategy whitelisting via Guard Engine
+- Proxy upgrade system
+- Bounded execution for slashing/misallocation defense
+
+---
+
+## 5. Outlook & Strategy Notes
+
+- Optimized reward collection to improve yield efficiency and auto-compounding

--- a/tokens/ynRWAx/reports/2026/ynrwax-june-2026.md
+++ b/tokens/ynRWAx/reports/2026/ynrwax-june-2026.md
@@ -1,0 +1,64 @@
+# YieldNest Monthly Report – ynRWAx (June 2026)
+
+![](https://raw.githubusercontent.com/yieldnest/Publications/refs/heads/main/assets/ynRWAx/report.png)
+
+---
+
+**Vault Asset**: ynRWAx
+**Vault Chain**: Ethereum Chain
+**Vault Type**: MAX
+**Vault Launch Date**: June 2025
+**Period Covered:** June 1 – June 30, 2026
+**Report Date:** July 1, 2026
+
+---
+
+## 1. Executive Summary
+
+[ynRWAx](https://app.yieldnest.finance/token/ynRWAx) is YieldNest's MAX product deployed on Ethereum Chain. It auto-compounds USD yield through RWA-native strategies, offering liquid exposure and ETH L1 settlement.
+
+_Return accrues as the value of ynRWAx increases relative to USDC._
+
+---
+
+## 2. Vault Overview Report (as of July 1, 2026)
+
+### Monthly Overview Report
+
+- Vault TVL: $9,233,298.60
+- APY stats from June:
+    - 2026-06-23 - 2026-06-30: 13.32%
+    - 2026-06-01 - 2026-06-30: 11.28%
+
+---
+
+## 3. Strategy Breakdown (as of July 1, 2026)
+
+| Asset / Strategy | Allocation | Protocol | Description |
+| --- | --- | --- | --- |
+| MAX RWA | 99.92% | - | Rewards are generated from real estate backed credit strategies managed by Kimber Capital. ynRWAx may be redeemed for a 7 day period upon maturity. Upon completion of the redemption period, an automatic roll over will take place. MAX RWA is capped to be no more than 5% of the gross LTV of a diversified pool of secured RWA credit with full recourse. |
+| USDC | 0.08% | – | Freshly deposited USDC, held as idle capital and ready to be deployed into yield or arbitrage strategies. |
+
+---
+
+## 4. Security & Risk Monitoring
+
+Audited Completed:
+
+- [Zokyo - Dec 2024](https://github.com/yieldnest/Publications/blob/main/audits/zokyo_audit_yieldnest_dec12th_2024.pdf)
+- [Composable Security - Jan 2025](https://github.com/yieldnest/Publications/blob/main/audits/composable_security_yieldnest_jan_2025.pdf)
+- [Llamarisk - Jan 2025](https://www.llamarisk.com/research/asset-risk-ynbnbx)
+- [NFR Audits Feb 2025](https://github.com/yieldnest/Publications/blob/main/audits/yieldnest_max_vault_withdrawer_audit_report.pdf)
+
+On-Chain Protections:
+
+- ERC-4626 modular vaults
+- Strategy whitelisting via Guard Engine
+- Proxy upgrade system
+- Bounded execution for slashing/misallocation defense
+
+---
+
+## 5. Outlook & Strategy Notes
+
+- Optimized reward collection to improve yield efficiency and auto-compounding

--- a/tokens/ynUSDx/reports/2026/ynusdx-june-2026.md
+++ b/tokens/ynUSDx/reports/2026/ynusdx-june-2026.md
@@ -1,0 +1,66 @@
+# YieldNest Monthly Report – ynUSDx (June 2026)
+
+![](https://raw.githubusercontent.com/yieldnest/Publications/refs/heads/main/assets/ynUSDx/report.png)
+
+---
+
+**Vault Asset**: ynUSDx
+**Vault Chain**: Ethereum Chain
+**Vault Type**: MAX
+**Vault Launch Date**: June 2025
+**Period Covered:** June 1 – June 30, 2026
+**Report Date:** July 1, 2026
+
+---
+
+## 1. Executive Summary
+
+[ynUSDx](https://app.yieldnest.finance/token/ynUSDx) is YieldNest's MAX product deployed on Ethereum Chain. It auto-compounds USD yield through DeFi-native strategies, offering liquid exposure and ETH L1 settlement.
+
+_Return accrues as the value of ynUSDx increases relative to USDC._
+
+---
+
+## 2. Vault Overview Report (as of July 1, 2026)
+
+### Monthly Overview Report
+
+- Vault TVL: $353,179.90
+- APY stats from June:
+    - 2026-06-23 - 2026-06-30: 12.38%
+    - 2026-06-01 - 2026-06-30: 10.01%
+
+---
+
+## 3. Strategy Breakdown (as of July 1, 2026)
+
+| Asset / Strategy | Allocation | Protocol | Description |
+| --- | --- | --- | --- |
+| USDC Arbitrage | 58.00% | YieldNest | Delta Neutral Arbitrage Strategy compounding rewards in USDC. |
+| USDC Lending | 37.59% | Euler | Earns rewards by lending USDC on Euler to borrow against ynRWAx. |
+| USDC | 3.46% | – | Freshly deposited USDC, held as idle capital and ready to be deployed into yield or arbitrage strategies. |
+| USDC RWA Lending | 0.95% | Morpho | Earns rewards by lending USDC on Morpho to the YieldNest RWA market while supporting instant withdrawals for ynUSDx. |
+
+---
+
+## 4. Security & Risk Monitoring
+
+Audited Completed:
+
+- [Zokyo - Dec 2024](https://github.com/yieldnest/Publications/blob/main/audits/zokyo_audit_yieldnest_dec12th_2024.pdf)
+- [Composable Security - Jan 2025](https://github.com/yieldnest/Publications/blob/main/audits/composable_security_yieldnest_jan_2025.pdf)
+- [Llamarisk - Jan 2025](https://www.llamarisk.com/research/asset-risk-ynbnbx)
+- [NFR Audits Feb 2025](https://github.com/yieldnest/Publications/blob/main/audits/yieldnest_max_vault_withdrawer_audit_report.pdf)
+
+On-Chain Protections:
+
+- ERC-4626 modular vaults
+- Strategy whitelisting via Guard Engine
+- Proxy upgrade system
+- Bounded execution for slashing/misallocation defense
+
+---
+
+## 5. Outlook & Strategy Notes
+
+- Optimized reward collection to improve yield efficiency and auto-compounding


### PR DESCRIPTION
Adds the June 2026 monthly reports for all five vaults/tokens:

- STAK
- ynBNBx
- ynETHx
- ynRWAx
- ynUSDx

Each report follows the established monthly-report format and references its report image from `assets/<TOKEN>/report.png` on `main`.

Note: this is scoped to June only and is independent of PR #17 (March/April/May), so it can be reviewed and merged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)